### PR TITLE
Improve formatting of multi-line messages

### DIFF
--- a/zenlog/__init__.py
+++ b/zenlog/__init__.py
@@ -33,31 +33,31 @@ class Log:
     # to inject new items into the logging.LogRecord objects
     # we also create our convenience methods here
     def critical(self, message, *args, **kwargs):
-        for line in message.splitlines():
+        for line in str(message).splitlines():
             self.logger.critical(line,
                                  extra={"styledname": self.theme[logging.CRITICAL]},
                                  *args, **kwargs)
     crit = c = fatal = critical
     def error(self, message, *args, **kwargs):
-        for line in message.splitlines():
+        for line in str(message).splitlines():
             self.logger.error(line,
                               extra={"styledname": self.theme[logging.ERROR]},
                               *args, **kwargs)
     err = e = error
     def warn(self, message, *args, **kwargs):
-        for line in message.splitlines():
+        for line in str(message).splitlines():
             self.logger.warn(line,
                              extra={"styledname": self.theme[logging.WARNING]},
                              *args, **kwargs)
     warning = w = warn
     def info(self, message, *args, **kwargs):
-        for line in message.splitlines():
+        for line in str(message).splitlines():
             self.logger.info(line,
                              extra={"styledname": self.theme[logging.INFO]},
                              *args, **kwargs)
     inf = nfo = i = info
     def debug(self, message, *args, **kwargs):
-        for line in message.splitlines():
+        for line in str(message).splitlines():
             self.logger.debug(line,
                               extra={"styledname": self.theme[logging.DEBUG]},
                               *args, **kwargs)

--- a/zenlog/__init__.py
+++ b/zenlog/__init__.py
@@ -33,29 +33,34 @@ class Log:
     # to inject new items into the logging.LogRecord objects
     # we also create our convenience methods here
     def critical(self, message, *args, **kwargs):
-        self.logger.critical(message,
-                             extra={"styledname": self.theme[logging.CRITICAL]},
-                             *args, **kwargs)
+        for line in message.splitlines():
+            self.logger.critical(line,
+                                 extra={"styledname": self.theme[logging.CRITICAL]},
+                                 *args, **kwargs)
     crit = c = fatal = critical
     def error(self, message, *args, **kwargs):
-        self.logger.error(message,
-                          extra={"styledname": self.theme[logging.ERROR]},
-                          *args, **kwargs)
+        for line in message.splitlines():
+            self.logger.error(line,
+                              extra={"styledname": self.theme[logging.ERROR]},
+                              *args, **kwargs)
     err = e = error
     def warn(self, message, *args, **kwargs):
-        self.logger.warn(message,
-                         extra={"styledname": self.theme[logging.WARNING]},
-                         *args, **kwargs)
+        for line in message.splitlines():
+            self.logger.warn(line,
+                             extra={"styledname": self.theme[logging.WARNING]},
+                             *args, **kwargs)
     warning = w = warn
     def info(self, message, *args, **kwargs):
-        self.logger.info(message,
-                         extra={"styledname": self.theme[logging.INFO]},
-                         *args, **kwargs)
+        for line in message.splitlines():
+            self.logger.info(line,
+                             extra={"styledname": self.theme[logging.INFO]},
+                             *args, **kwargs)
     inf = nfo = i = info
     def debug(self, message, *args, **kwargs):
-        self.logger.debug(message,
-                          extra={"styledname": self.theme[logging.DEBUG]},
-                          *args, **kwargs)
+        for line in message.splitlines():
+            self.logger.debug(line,
+                              extra={"styledname": self.theme[logging.DEBUG]},
+                              *args, **kwargs)
     dbg = d = debug
 
     # other convenience functions to set the global logging level


### PR DESCRIPTION
Fix #2

Splits multi-line strings into a list of lines, then logs each one in order.

This means that long messages are now aligned correctly:

``` python
log.c('CRITICAL\nCRITICAL')
log.e('ERROR\nERROR')
log.w('WARNING\nWARNING')
log.i('INFO\nINFO')
log.d('DEBUG\nDEBUG')
```

now prints

```
   [!!!!!]  | CRITICAL
   [!!!!!]  | CRITICAL
    [!!!]   | ERROR
    [!!!]   | ERROR
     [!]    | WARNING
     [!]    | WARNING
      i     | INFO
      i     | INFO
     ...    | DEBUG
     ...    | DEBUG
```
