### PR TITLE
Fix ability to provide a custom format

### DIFF
--- a/zenlog/__init__.py
+++ b/zenlog/__init__.py
@@ -28,7 +28,8 @@ class Log:
     def __init__(self, lvl=logging.DEBUG, format=None):
         self._lvl = lvl
         if not format:
-            self.format = "  %(log_color)s%(styledname)-8s%(reset)s | %(log_color)s%(message)s%(reset)s"
+            format = "  %(log_color)s%(styledname)-8s%(reset)s | %(log_color)s%(message)s%(reset)s"
+        self.format = format
         logging.root.setLevel(self._lvl)
         self.formatter = colorlog.ColoredFormatter(self.format)
         self.stream = logging.StreamHandler()


### PR DESCRIPTION
I tried to pass in a custom format: 
` Log(format='%(log_color)s%(message)s%(reset)s')`
but I got an error that `self.format` wasn't defined